### PR TITLE
template: Add PR step for updating documentation

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -33,3 +33,4 @@
 - [ ] My code is not on the master branch.
 - [ ] The code has been tested.
 - [ ] All commit messages are properly formatted and commits squashed where appropriate.
+- [ ] I have included updates to all appropriate documentation.


### PR DESCRIPTION
### Description
Add a new step to the pull request template requesting that people update documentation when they make relevant changes.

### Motivation and Context
Many times, we will get pull requests that make changes to libobs, but do not include the appropriate changes to the documentation. This leads to the API documentation becoming out of date as more features and changes are merged.

### How Has This Been Tested?
I added the same line to this PR and verified that the markdown rendered correctly.

### Types of changes
- Documentation (a change to documentation pages)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [ ] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
