### PR TITLE
template: Remove default title

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,6 @@
 ---
 name: Bug report
 about: Application crashes or bugs
-title: "[BUG] <bug description>"
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
### Description
Remove default bug report title from template

### Motivation and Context
The [BUG] tag is redundant with Github labels, and people keep
forgetting to set a title, so we'd like to force people to set a title
by making it blank by default.

### How Has This Been Tested?
I attempted to open a new bug report on my own fork of this repo. The title was blank, as expected, and Github would not let me submit the issue without a title.

### Types of changes
- Documentation (a change to documentation pages

### Checklist:
- [n/a] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
